### PR TITLE
Update kill with database

### DIFF
--- a/appGeo/src/app/chat/chat.component.html
+++ b/appGeo/src/app/chat/chat.component.html
@@ -96,7 +96,7 @@
 
 </TextField>
 
-<button (tap)="save()" class="btn btn-primary active" text="Save"></button>
+<button (tap)="save()" *ngIf="this.is_alive" class="btn btn-primary active" text="Save"></button>
       </StackLayout>
   </ScrollView>
 </StackLayout>

--- a/appGeo/src/app/chat/chat.component.ts
+++ b/appGeo/src/app/chat/chat.component.ts
@@ -22,7 +22,9 @@ const bindingContext = fromObject(model)
 })
 
 export class ChatComponent implements OnInit {
-
+    public DEAD = 0
+    public ALIVE = 1
+    public is_alive: Boolean
     text: string = ""
     save() {
         if (global.loggedIn && global.player.username != "") {
@@ -84,6 +86,15 @@ export class ChatComponent implements OnInit {
     databaseEventListener("game/chats", this.updateMsg.bind(this));
     console.log("got to chat");
     console.log("Can we see the player location in chat? Here it is: ", global.player.location)
+    if (global.player.alive == this.ALIVE){
+        //testing
+        this.is_alive = true;
+        console.log("We are in the case of having an alive player")
+    }
+    else{
+        this.is_alive = false;
+        console.log("We are in the case of having a dead player")
+    }
   }
 
   getMsgs() {

--- a/appGeo/src/app/home/home.component.html
+++ b/appGeo/src/app/home/home.component.html
@@ -17,7 +17,7 @@
       <Button [text]="text" *ngIf="is_component_not_loggedIn | async" (tap)="login()" class="btn home" style="color:red"></Button>
       <Button text="Go To Chat" *ngIf="is_component_loggedIn | async" [nsRouterLink]="['Chat']" class="btn btn-primary btn-active home" col="0"></Button>
       <Button text="Go To Snapshot" *ngIf="is_component_loggedIn | async" [nsRouterLink]="['Snapshot']" class="btn btn-primary btn-active" col="0"></Button>
-      <Button text="Kill a Player" *ngIf="this.isKiller && !this.votingOpen && is_component_loggedIn | async" [nsRouterLink]="['Killing']" class="btn btn-primary btn-active home" col="0"></Button>
+      <Button text="Kill a Player" *ngIf="(isKiller | async) && !this.votingOpen && is_component_loggedIn" [nsRouterLink]="['Killing']" class="btn btn-primary btn-active home" col="0"></Button>
       <Button text="Go to Vote Player" *ngIf="this.votingOpen && is_component_loggedIn | async" [nsRouterLink]="['Voting']" class="btn btn-primary btn-active home" col="0"></Button>
       <!-- <Button text="Go to Geolocation" *ngIf="is_component_loggedIn | async" [nsRouterLink]="['Location']" class="btn btn-primary btn-active" col="0"></Button> -->
       <Button text="Players Nearby" *ngIf="is_component_loggedIn | async" [nsRouterLink]="['campusMap']" class="btn btn-primary btn-active home" col="0"></Button>

--- a/appGeo/src/app/home/home.component.ts
+++ b/appGeo/src/app/home/home.component.ts
@@ -55,7 +55,7 @@ export class HomeComponent implements OnInit {
 
   ngOnInit(): void {
     this.isKiller = true;   //This information should be received from Database with Player Info!!!
-    this.votingOpen = false; //This information should be received from Database with Game Info!!!
+    this.votingOpen = true; //This information should be received from Database with Game Info!!!
     console.log("Can we see this when we exit the page and then come back inside the page")
     // Init your component properties here.
     // Going to initialize a list of bubbles here;

--- a/appGeo/src/app/home/home.component.ts
+++ b/appGeo/src/app/home/home.component.ts
@@ -70,7 +70,7 @@ export class HomeComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.isKiller = true;   //This information should be received from Database with Player Info!!!
+    //this.isKiller = true;   //This information should be received from Database with Player Info!!!
     this.votingOpen = true; //This information should be received from Database with Game Info!!!
     console.log("Can we see this when we exit the page and then come back inside the page")
     // Init your component properties here.
@@ -223,6 +223,7 @@ export class HomeComponent implements OnInit {
     if(global.player.isadmin == true) {
       databaseEventListener("src/game/gameStarted", this.startGameDatabase.bind(this))
     }
+    this.isKiller = global.player.isKiller;
   }
 
   updateVoteOpenDatabase(data: object) {

--- a/appGeo/src/app/home/home.component.ts
+++ b/appGeo/src/app/home/home.component.ts
@@ -224,6 +224,12 @@ export class HomeComponent implements OnInit {
       databaseEventListener("src/game/gameStarted", this.startGameDatabase.bind(this))
     }
     this.isKiller = global.player.isKiller;
+    if (this.isKiller = true){
+      console.log("The current user is a killer")
+    }
+    else{
+      console.log("The current user is a civilian")
+    }
   }
 
   updateVoteOpenDatabase(data: object) {

--- a/appGeo/src/app/home/home.component.ts
+++ b/appGeo/src/app/home/home.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, NgZone } from '@angular/core'
 import {Bubble} from '../map/map.component'
-import {Player} from '../player/player.component'
+import {Killer, Player} from '../player/player.component'
 import {CampusMap} from '../map/campus-map.component'
 import { Chat } from '../chat/chat.component'
 import { Game } from '../game/game.component'
@@ -35,7 +35,7 @@ export class HomeComponent implements OnInit {
 
   text : string = "Google Sign-In";
 
-  public isKiller: Boolean
+  public isKiller: Observable<Boolean>
   public votingOpen: Boolean
   public component_isLoggedIn: Boolean
   public is_component_loggedIn: Observable<Boolean>
@@ -62,16 +62,22 @@ export class HomeComponent implements OnInit {
     if(global.loggedIn){
       this.is_component_loggedIn = new Observable(observer=>observer.next(true));
       this.is_component_not_loggedIn = new Observable(observer=>observer.next(false));
+      if (global.player instanceof Killer || global.player.isKiller == true){
+        this.isKiller = new Observable(observer=>observer.next(true));
+      }
+      else{
+        this.isKiller = new Observable(observer=>observer.next(false));
+      }
     }
     else{
       this.is_component_loggedIn = new Observable(observer=>observer.next(false));
       this.is_component_not_loggedIn = new Observable(observer=>observer.next(true));
+      this.isKiller = new Observable(observer=>observer.next(false));
     }
   }
 
   ngOnInit(): void {
-    //this.isKiller = true;   //This information should be received from Database with Player Info!!!
-    this.votingOpen = true; //This information should be received from Database with Game Info!!!
+    this.votingOpen = false; //This information should be received from Database with Game Info!!!
     console.log("Can we see this when we exit the page and then come back inside the page")
     // Init your component properties here.
     // Going to initialize a list of bubbles here;
@@ -108,6 +114,12 @@ export class HomeComponent implements OnInit {
       this.zone.run(() => this.component_isLoggedIn = true)
       this.is_component_loggedIn = new Observable(observer=>observer.next(true));
       this.is_component_not_loggedIn = new Observable(observer=>observer.next(false));
+      if (global.player instanceof Killer || global.player.isKiller == true){
+        this.isKiller = new Observable(observer=>observer.next(true));
+      }
+      else{
+        this.isKiller = new Observable(observer=>observer.next(false));
+      }
 
       let options = {
         title: "Error",
@@ -156,6 +168,12 @@ export class HomeComponent implements OnInit {
                 this.zone.run(() => this.component_isLoggedIn = true)
                 this.is_component_loggedIn = new Observable(observer=>observer.next(true));
                 this.is_component_not_loggedIn = new Observable(observer=>observer.next(false));
+                if (global.player instanceof Killer || global.player.isKiller == true){
+                  this.isKiller = new Observable(observer=>observer.next(true));
+                }
+                else{
+                  this.isKiller = new Observable(observer=>observer.next(false));
+                }
                 //console.log(global.player);
 
                 databaseAdd('/game/users/' + userID, global.player)
@@ -165,14 +183,21 @@ export class HomeComponent implements OnInit {
 
             }
             //already exists
-            else {
+            else { 
               global.player = res["value"];
               console.log("user already exists, will not add new data but will pull from the database");
-              //console.log(global.player);
+              console.log(global.player);
+              console.log("At this point in time the isKiller flag for globabl is: ", global.player.isKiller)
               global.result = res;
               this.zone.run(() => this.component_isLoggedIn = true)
               this.is_component_loggedIn = new Observable(observer=>observer.next(true));
               this.is_component_not_loggedIn = new Observable(observer=>observer.next(false));
+              if (global.player instanceof Killer || global.player.isKiller == true){
+                this.isKiller = new Observable(observer=>observer.next(true));
+              }
+              else{
+                this.isKiller = new Observable(observer=>observer.next(false));
+              }
               this.startWatchingLocation();
             }
           }).then(res2 => {
@@ -181,6 +206,12 @@ export class HomeComponent implements OnInit {
               this.zone.run(() => this.component_isLoggedIn = true)
               this.is_component_loggedIn = new Observable(observer=>observer.next(true));
               this.is_component_not_loggedIn = new Observable(observer=>observer.next(false));
+              if (global.player instanceof Killer || global.player.isKiller == true){
+                this.isKiller = new Observable(observer=>observer.next(true));
+              }
+              else{
+                this.isKiller = new Observable(observer=>observer.next(false));
+              }
               this.startWatchingLocation();
               console.log(global.loggedIn);
             }
@@ -222,13 +253,6 @@ export class HomeComponent implements OnInit {
 
     if(global.player.isadmin == true) {
       databaseEventListener("src/game/gameStarted", this.startGameDatabase.bind(this))
-    }
-    this.isKiller = global.player.isKiller;
-    if (this.isKiller = true){
-      console.log("The current user is a killer")
-    }
-    else{
-      console.log("The current user is a civilian")
     }
   }
 

--- a/appGeo/src/app/player/killing.component.html
+++ b/appGeo/src/app/player/killing.component.html
@@ -5,7 +5,7 @@
     <ScrollView (scroll)="onScroll($any($event))">
         <StackLayout orientation="vertical">
             <label>You have currently selected: {{this.selected_player_username}} </label>
-            <button *ngIf="this.can_kill" (tap)="killPlayer()" class="btn btn-primary active" text="Kill the selected user!" ></button>
+            <button *ngIf="this.can_kill && this.is_alive" (tap)="killPlayer()" class="btn btn-primary active" text="Kill the selected user!" ></button>
             <TextField hint="Type username of person you want to kill" [(ngModel)]="this.typed_username">
             </TextField>
             <button (tap)="selectPlayer()" class="btn btn-primary active" text="Select player matching the typed username"></button>

--- a/appGeo/src/app/player/killing.component.ts
+++ b/appGeo/src/app/player/killing.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
-import { databaseAdd, databaseGet, databaseEventListener } from '../../modules/database'
+import { databaseAdd, databaseGet, databaseEventListener, databaseUpdate } from '../../modules/database'
 import { firebase } from "@nativescript/firebase";
 import { fromObject, ScrollView, ScrollEventData} from '@nativescript/core';
 import { Player, Killer, Civilian } from './player.component'
@@ -171,6 +171,10 @@ export class KillingComponent implements OnInit {
 
         //Display satisfactory message for killing ;)
         this.selected_player_username = this.selected_player_username + " is now dead... Congrats ^_^"
+
+        //Update things in terms of the database
+        databaseUpdate(this.selected_player.databasePath, this.selected_player)
+        databaseUpdate(this.yourself.databasePath, this.yourself)
     }
 
 }

--- a/appGeo/src/app/player/killing.component.ts
+++ b/appGeo/src/app/player/killing.component.ts
@@ -3,6 +3,8 @@ import { databaseAdd, databaseGet, databaseEventListener } from '../../modules/d
 import { firebase } from "@nativescript/firebase";
 import { fromObject, ScrollView, ScrollEventData} from '@nativescript/core';
 import { Player, Killer, Civilian } from './player.component'
+import {CampusMap} from '../map/campus-map.component';
+import {Bubble} from '../map/map.component';
 
 @Component({
   selector: 'Killing',
@@ -53,26 +55,42 @@ export class KillingComponent implements OnInit {
 
         //We also want to get the Object that represents the killer:
         //yourself = <some way from databases to get back Killer Object matching to the user>
+        this.yourself = global.player
 
         this.list_of_all_available_to_kill = new Array();
         this.list_of_all_nearby_players = new Array();
         this.selected_player = null;
 
-        //Hard code some examples::
-        var player1 = new Civilian()
-        player1.init(1, "Testing 1", 1, this.ALIVE)
-        var player2 = new Civilian()
-        player2.init(2, "Testing 2", 1, this.ALIVE)
-        var player3 = new Civilian()
-        player3.init(3, "Testing 3", 1, this.ALIVE)
-        this.yourself = new Killer()
-        this.yourself.init(4, "This is you, you killer", 1, this.ALIVE)
-        var killer2 = new Killer()
-        killer2.init(5, "Killer that should never show up", 1, this.ALIVE)
-        this.list_of_all_nearby_players.push(player1)
-        this.list_of_all_nearby_players.push(player2)
-        this.list_of_all_nearby_players.push(player3)
-        this.list_of_all_nearby_players.push(killer2)
+        let cm = new CampusMap();
+        databaseGet('game/map').then(value => {
+          console.log("val: " + JSON.stringify(value));
+    
+          if (value == null) {
+            console.log("Found error where I can't draw from the map")
+          } 
+          else {
+            cm = value;
+            var curr_bub = cm.playersBubble(global.player);
+            this.list_of_all_nearby_players = Array.from(curr_bub.List.values());
+          }
+        });
+
+
+        // //Hard code some examples::
+        // var player1 = new Civilian()
+        // player1.init(1, "Testing 1", 1, this.ALIVE)
+        // var player2 = new Civilian()
+        // player2.init(2, "Testing 2", 1, this.ALIVE)
+        // var player3 = new Civilian()
+        // player3.init(3, "Testing 3", 1, this.ALIVE)
+        // this.yourself = new Killer()
+        // this.yourself.init(4, "This is you, you killer", 1, this.ALIVE)
+        // var killer2 = new Killer()
+        // killer2.init(5, "Killer that should never show up", 1, this.ALIVE)
+        // this.list_of_all_nearby_players.push(player1)
+        // this.list_of_all_nearby_players.push(player2)
+        // this.list_of_all_nearby_players.push(player3)
+        // this.list_of_all_nearby_players.push(killer2)
 
     //The following lines would work whenevever have an appropriate 'yourself' object
         this.kills_remaining = this.yourself.getRemainingDailyKillCount()

--- a/appGeo/src/app/player/killing.component.ts
+++ b/appGeo/src/app/player/killing.component.ts
@@ -70,8 +70,14 @@ export class KillingComponent implements OnInit {
             console.log("Found error where I can't draw from the map")
           } 
           else {
-            cm = value;
+            cm.MapOfCampus = value.MapOfCampus
+            cm.display = value.display
+            cm.playerlist = value.player_list
+            cm.offcampus = value.offcampus
+            console.log("cm variable is now: ", cm)
+            console.log("The lcoation of the player is currently: ", global.player.location)
             var curr_bub = cm.playersBubble(global.player);
+            
             this.list_of_all_nearby_players = Array.from(curr_bub.List.values());
           }
         });

--- a/appGeo/src/app/player/killing.component.ts
+++ b/appGeo/src/app/player/killing.component.ts
@@ -51,11 +51,8 @@ export class KillingComponent implements OnInit {
 
     ngOnInit(): void {
         console.log("Got to Killing Screen")
-        //Here we want to get from database the list of players that are in bubble
-        //list_of_all_nearby_players = <some way from database to return a list of Player Objects that are all in same bubble as user>
 
-        //We also want to get the Object that represents the killer:
-        //yourself = <some way from databases to get back Killer Object matching to the user>
+        //Setting yourself from the global object
         this.yourself = global.player
 
         this.list_of_all_available_to_kill = new Array();
@@ -69,41 +66,6 @@ export class KillingComponent implements OnInit {
 
         //After getting map object, just extract the playerlist and reassign value
         this.list_of_all_nearby_players = cm.playerlist; 
-        // databaseGet('game/map').then(value => {
-        //   console.log("val: " + JSON.stringify(value));
-    
-        //   if (value == null) {
-        //     console.log("Found error where I can't draw from the map")
-        //   } 
-        //   else {
-        //     cm.MapOfCampus = value.MapOfCampus
-        //     cm.display = value.display
-        //     cm.playerlist = value.player_list
-        //     cm.offcampus = value.offcampus
-        //     console.log("cm variable is now: ", cm)
-        //     console.log("The lcoation of the player is currently: ", global.player.location)
-        //     var curr_bub = cm.playersBubble(global.player);
-            
-        //     this.list_of_all_nearby_players = Array.from(curr_bub.List.values());
-        //   }
-        // });
-
-
-        // //Hard code some examples::
-        // var player1 = new Civilian()
-        // player1.init(1, "Testing 1", 1, this.ALIVE)
-        // var player2 = new Civilian()
-        // player2.init(2, "Testing 2", 1, this.ALIVE)
-        // var player3 = new Civilian()
-        // player3.init(3, "Testing 3", 1, this.ALIVE)
-        // this.yourself = new Killer()
-        // this.yourself.init(4, "This is you, you killer", 1, this.ALIVE)
-        // var killer2 = new Killer()
-        // killer2.init(5, "Killer that should never show up", 1, this.ALIVE)
-        // this.list_of_all_nearby_players.push(player1)
-        // this.list_of_all_nearby_players.push(player2)
-        // this.list_of_all_nearby_players.push(player3)
-        // this.list_of_all_nearby_players.push(killer2)
 
     //The following lines would work whenevever have an appropriate 'yourself' object
         this.kills_remaining = this.yourself.remaining_daily_kill_count;
@@ -128,8 +90,6 @@ export class KillingComponent implements OnInit {
     }
 
     filterPlayers(){
-        //console.log("Inside the filter Killer function")
-        //console.log("The length of list of all nearby players is: ", this.list_of_all_nearby_players.length)
         for(var i = 0; i < this.list_of_all_nearby_players.length; i++){
             var curr_player = this.list_of_all_nearby_players[i];
             //We cannot kill an already dead player, and we also cannot kill another killer
@@ -141,7 +101,6 @@ export class KillingComponent implements OnInit {
                     console.log("We have added the current user to the list of killable targets, OOOPS!")
                 }
                 this.list_of_all_available_to_kill.push(curr_player);
-                //console.log("We have just now added the following to available: ", curr_player.getUserID())
             }
         }
     }

--- a/appGeo/src/app/player/killing.component.ts
+++ b/appGeo/src/app/player/killing.component.ts
@@ -23,6 +23,7 @@ export class KillingComponent implements OnInit {
     public kills_remaining: number
     public commited_kills: number
     public can_kill: Boolean
+    public is_alive: Boolean
 
     public selected_player: Player
     public selected_player_username: string = ""
@@ -93,8 +94,16 @@ export class KillingComponent implements OnInit {
         // this.list_of_all_nearby_players.push(killer2)
 
     //The following lines would work whenevever have an appropriate 'yourself' object
-        this.kills_remaining = this.yourself.getRemainingDailyKillCount()
-        this.commited_kills = this.yourself.getTotalKillCount()
+        this.kills_remaining = this.yourself.remaining_daily_kill_count;
+        this.commited_kills = this.yourself.total_kill_count;
+        if (this.yourself.alive == this.ALIVE){
+            this.is_alive = true;
+        }
+        else{
+            this.is_alive = false;
+        }
+        // this.kills_remaining = this.yourself.getRemainingDailyKillCount()
+        // this.commited_kills = this.yourself.getTotalKillCount()
         // this.kills_remaining = 3
         // this.commited_kills = 2
         if (this.kills_remaining > 0){

--- a/appGeo/src/app/player/killing.component.ts
+++ b/appGeo/src/app/player/killing.component.ts
@@ -62,25 +62,31 @@ export class KillingComponent implements OnInit {
         this.list_of_all_nearby_players = new Array();
         this.selected_player = null;
 
+        /* Create a new campus map object and then call playersBubble() to load 
+         * depending on the user's location */
         let cm = new CampusMap();
-        databaseGet('game/map').then(value => {
-          console.log("val: " + JSON.stringify(value));
+        cm.playersBubble(global.player);
+
+        //After getting map object, just extract the playerlist and reassign value
+        this.list_of_all_nearby_players = cm.playerlist; 
+        // databaseGet('game/map').then(value => {
+        //   console.log("val: " + JSON.stringify(value));
     
-          if (value == null) {
-            console.log("Found error where I can't draw from the map")
-          } 
-          else {
-            cm.MapOfCampus = value.MapOfCampus
-            cm.display = value.display
-            cm.playerlist = value.player_list
-            cm.offcampus = value.offcampus
-            console.log("cm variable is now: ", cm)
-            console.log("The lcoation of the player is currently: ", global.player.location)
-            var curr_bub = cm.playersBubble(global.player);
+        //   if (value == null) {
+        //     console.log("Found error where I can't draw from the map")
+        //   } 
+        //   else {
+        //     cm.MapOfCampus = value.MapOfCampus
+        //     cm.display = value.display
+        //     cm.playerlist = value.player_list
+        //     cm.offcampus = value.offcampus
+        //     console.log("cm variable is now: ", cm)
+        //     console.log("The lcoation of the player is currently: ", global.player.location)
+        //     var curr_bub = cm.playersBubble(global.player);
             
-            this.list_of_all_nearby_players = Array.from(curr_bub.List.values());
-          }
-        });
+        //     this.list_of_all_nearby_players = Array.from(curr_bub.List.values());
+        //   }
+        // });
 
 
         // //Hard code some examples::
@@ -108,10 +114,7 @@ export class KillingComponent implements OnInit {
         else{
             this.is_alive = false;
         }
-        // this.kills_remaining = this.yourself.getRemainingDailyKillCount()
-        // this.commited_kills = this.yourself.getTotalKillCount()
-        // this.kills_remaining = 3
-        // this.commited_kills = 2
+
         if (this.kills_remaining > 0){
             this.can_kill = true;
         }
@@ -130,10 +133,13 @@ export class KillingComponent implements OnInit {
         for(var i = 0; i < this.list_of_all_nearby_players.length; i++){
             var curr_player = this.list_of_all_nearby_players[i];
             //We cannot kill an already dead player, and we also cannot kill another killer
-            if (curr_player.getAliveStatus() != this.ALIVE || curr_player instanceof Killer){
+            if (curr_player.alive != this.ALIVE || curr_player instanceof Killer || curr_player.username == this.yourself.username){
                 //Do nothing
             }
             else{
+                if (curr_player.username == this.yourself.username){
+                    console.log("We have added the current user to the list of killable targets, OOOPS!")
+                }
                 this.list_of_all_available_to_kill.push(curr_player);
                 //console.log("We have just now added the following to available: ", curr_player.getUserID())
             }
@@ -146,9 +152,9 @@ export class KillingComponent implements OnInit {
         for(var i = 0; i < this.list_of_all_nearby_players.length; i++){
             var curr_player = this.list_of_all_nearby_players[i];
             //Check if this is the player of who you want to kill
-            if (curr_player.getUsername() == this.typed_username){
+            if (curr_player.username == this.typed_username){
                 this.selected_player = curr_player;
-                this.selected_player_username = curr_player.getUsername();
+                this.selected_player_username = curr_player.username;
                 found = true;
                 break;
             }
@@ -171,12 +177,12 @@ export class KillingComponent implements OnInit {
 
         //Do the selection process
         this.selected_player = player_passed_in;
-        this.selected_player_username = player_passed_in.getUsername();
+        this.selected_player_username = player_passed_in.username;
     }
 
     removePlayer(){
         const index_we_found = this.list_of_all_available_to_kill.findIndex((object) => {
-            return object.getUsername() === this.selected_player.getUsername();
+            return object.username === this.selected_player.username;
         });
 
         if (index_we_found !== -1) {

--- a/appGeo/src/app/player/player.component.ts
+++ b/appGeo/src/app/player/player.component.ts
@@ -47,6 +47,7 @@ export class Player implements OnInit{
         this.chat_lists = new Array();
         this.databasePath = "";
         this.isAdmin = false;
+        this.isKiller = false;
         
     }
     //init(userID: number, userIDString: string, username: string, email:string, location, alive: number){
@@ -66,6 +67,7 @@ export class Player implements OnInit{
         this.chat_lists = new Array()
         this.databasePath = "";
         this.isAdmin = false;
+        this.isKiller = false;
     }
     ngOnInit(): void {
     }

--- a/appGeo/src/app/player/player.component.ts
+++ b/appGeo/src/app/player/player.component.ts
@@ -28,7 +28,7 @@ export class Player implements OnInit{
     votes: number // An int
     chat_lists // List of Chat Objects that Player is a part of
     isAdmin : boolean // boolean whether this player is an admin (as in responsible for running the game start function)
-    
+    isKiller: boolean // boolean whether this player is a killer
     
     //edited by Kyu
     email: string;
@@ -252,7 +252,8 @@ export class Civilian extends Player{
     /* Currently will be just the same as Player Superclass, however this info
     may change when implementing chat feature or in the future */
     constructor(){
-      super()
+      super();
+      this.isKiller = false;
     }
     init(userID: number, username: string, location, alive: number){
         /* NOTE: we may not even need location anymore. After setting up geolocation
@@ -268,6 +269,7 @@ export class Civilian extends Player{
         this.alive = alive;
         this.votes = 0;
         this.chat_lists = new Array()
+        this.isKiller = false;
     }
 }
 
@@ -279,6 +281,7 @@ export class Killer extends Player{
 
     constructor(){
       super();
+      this.isKiller = true;
     }
 
     init(userID, username, location, alive){
@@ -298,6 +301,7 @@ export class Killer extends Player{
         this.max_daily_kill_count = DAILYMAXKILLCOUNT;
         this.remaining_daily_kill_count = DAILYMAXKILLCOUNT;
         this.total_kill_count = 0;
+        this.isKiller = true;
     }
 
     resetKilling() {

--- a/appGeo/src/app/voting/voting.component.html
+++ b/appGeo/src/app/voting/voting.component.html
@@ -5,7 +5,7 @@
     <ScrollView (scroll)="onScroll($any($event))">
         <StackLayout orientation="vertical">
             <label>You have currently selected: {{this.selected_player_username}} </label>
-            <button *ngIf="this.have_not_voted" (tap)="votePlayer()" class="btn btn-primary active" text="Vote for selected user!" ></button>
+            <button *ngIf="this.have_not_voted && this.is_alive" (tap)="votePlayer()" class="btn btn-primary active" text="Vote for selected user!" ></button>
             <TextField hint="Type username of person you want to vote off" [(ngModel)]="this.typed_username">
             </TextField>
             <button (tap)="selectPlayer()" class="btn btn-primary active" text="Select player matching the typed username"></button>

--- a/appGeo/src/app/voting/voting.component.ts
+++ b/appGeo/src/app/voting/voting.component.ts
@@ -34,7 +34,7 @@ export class VotingComponent implements OnInit{
     public selected_player_username: string = ""
     public typed_username: string = ""
     public selected_player: Player = null
-
+    public is_alive: Boolean
     constructor(){
 
     }
@@ -71,6 +71,16 @@ export class VotingComponent implements OnInit{
         else{
             //Otherwise, we can still vote!
             this.have_not_voted = true;
+        }
+
+        if (global.player.alive == this.ALIVE){
+            //testing
+            this.is_alive = true;
+            console.log("We are in the case of having an alive player")
+        }
+        else{
+            this.is_alive = false;
+            console.log("We are in the case of having a dead player")
         }
 
         this.filterPlayers();

--- a/appGeo/src/app/voting/voting.component.ts
+++ b/appGeo/src/app/voting/voting.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, Injectable, OnInit } from '@angular/core';
 import { InjectableAnimationEngine } from '@nativescript/angular';
+import { databaseAdd, databaseGet, databaseEventListener, databaseUpdate } from '../../modules/database'
 import { ChangeType } from '@nativescript/core';
 import { Bubble } from '../map/map.component';
 import {Player, Civilian, Killer} from '../player/player.component'
@@ -159,5 +160,9 @@ export class VotingComponent implements OnInit{
         this.front_message = this.msg_if_voted;
         this.yourself.have_already_voted = true; //Field inside the object gets set so it can go across pages
         this.have_not_voted = false; //Field that we use for the HTML in this page
+
+        //Update things in terms of the database
+        databaseUpdate(this.selected_player.databasePath, this.selected_player)
+        databaseUpdate(this.yourself.databasePath, this.yourself)
     }
 }


### PR DESCRIPTION
This PR includes a couple things:
* Dead Users cannot send chat messages (but they can see it)
* Dead Killers cannot kill other players
* Dead Users cannot vote for other players
* Killing component now grabs information from the surrounding bubble and only shows users that are viable to kill (aka, only those in the same bubble)
* IMPORTANT: Setting a isKiller flag inside the Player Class so that we can grab information from Firebase
    * The code for the Killing page _only_ being displayed for Killers is implemented in this PR, we just need to ensure that we can actually extract the code from firebase correctly.